### PR TITLE
Fix number of channels for encoder

### DIFF
--- a/omnidet/models/motion_decoder.py
+++ b/omnidet/models/motion_decoder.py
@@ -21,7 +21,7 @@ class MotionDecoder(nn.Module):
         super().__init__()
         self.n_classes = n_classes
 
-        self.num_ch_enc = num_ch_enc[64, 64, 128, 256, 512]
+        self.num_ch_enc = num_ch_enc  # [64, 64, 128, 256, 512]
         # [64, 64, 128, 256, 512] for motion_decoder and [128, 128, 256, 512, 1024] for siamese net
         self.num_ch_enc = num_ch_enc if not siamese_net else self.num_ch_enc * 2
         self.num_ch_dec = np.array([16, 32, 64, 128, 256]) if not siamese_net else np.array([16, 32, 64, 128, 256]) * 2


### PR DESCRIPTION
When I tried to run training code(`./main.py`), the following error has occurred. I fixed the number of channels for encoder.

```sh
  File "main.py", line 109, in <module>
    main()
  File "main.py", line 92, in main
    model = DistanceSemanticDetectionMotionModel(args)
  File "/home/tanutarou/WoodScape/omnidet/train_distance_semantic_detection_motion.py", line 25, in __init__
    super().__init__(args)
  File "/home/tanutarou/WoodScape/omnidet/train_distance_semantic_detection.py", line 30, in __init__
    super().__init__(args)
  File "/home/tanutarou/WoodScape/omnidet/train_distance_semantic_motion.py", line 27, in __init__
    self.models["motion"] = MotionDecoder(self.encoder_channels,
  File "/home/tanutarou/WoodScape/omnidet/models/motion_decoder.py", line 24, in __init__
    self.num_ch_enc = num_ch_enc[64, 64, 128, 256, 512]
IndexError: too many indices for array: array is 1-dimensional, but 5 were indexed
```